### PR TITLE
fix: switch to Debian Trixie, add full hardware support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ AIOS_BINS := aios-agent aios-chat aios-dock aios-confirm
 BIN_DIR   := iso/config/includes.chroot/usr/local/bin
 
 # -----------------------------------------------------------------------
-# Build Rust binaries for Linux x86_64 inside a Debian Bookworm container.
+# Build Rust binaries for Linux x86_64 inside a Debian Trixie container.
 # Docker volumes persist the Cargo registry and build cache across runs
 # to avoid full recompilation on every invocation.
 # Only the four ISO-targeted binaries are compiled.
@@ -31,7 +31,7 @@ install-binaries:
 	docker run --rm \
 		-v aios-target-cache:/src/target:ro \
 		-v "$(PWD)/$(BIN_DIR)":/output \
-		debian:bookworm \
+		debian:trixie \
 		sh -c 'cp $(addprefix /src/target/release/,$(AIOS_BINS)) /output/'
 	@echo "Installed binaries:"
 	@ls -lh $(BIN_DIR)/aios-*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AIOS — AI-First Operating System
 
-A minimal Linux distribution where the only interface is an AI chat and a web browser. Built on Debian Bookworm with a Rust-native UI stack.
+A minimal Linux distribution where the only interface is an AI chat and a web browser. Built on Debian Trixie with a Rust-native UI stack.
 
 ## Architecture
 
@@ -93,7 +93,7 @@ cargo clippy --workspace
 
 ## ISO Contents
 
-- **Base**: Debian 12 (Bookworm), kernel 6.1
+- **Base**: Debian 13 (Trixie), kernel 6.16+
 - **Window Manager**: sway (Wayland)
 - **Login**: greetd (auto-login as `aios`)
 - **Browser**: Chromium (managed policy, Wayland-native)

--- a/iso/Dockerfile
+++ b/iso/Dockerfile
@@ -3,7 +3,7 @@
 # Usage: docker build -t aios-iso-builder iso/
 #        docker run --rm --privileged -v $(pwd)/output:/output aios-iso-builder
 
-FROM debian:bookworm
+FROM debian:trixie
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/iso/Dockerfile.build
+++ b/iso/Dockerfile.build
@@ -1,8 +1,8 @@
 # AIOS Rust Build Container
-# Builds all Rust binaries inside Debian Bookworm to match the target ISO environment.
+# Builds all Rust binaries inside Debian Trixie to match the target ISO environment.
 # Usage: built automatically via `make build-linux`
 
-FROM debian:bookworm
+FROM debian:trixie
 
 # Install system dependencies required by Rust crates used in this workspace:
 #   - build-essential, pkg-config: base toolchain

--- a/iso/build-iso.sh
+++ b/iso/build-iso.sh
@@ -10,9 +10,11 @@ WORKSPACE="/workspace"
 mkdir -p "$WORKSPACE"
 
 echo "Copying build config to workspace..."
+rm -rf "$WORKSPACE/config" "$WORKSPACE/auto"
 cp -r /build-config/config "$WORKSPACE/config"
 cp -r /build-config/auto   "$WORKSPACE/auto"
 chmod +x "$WORKSPACE/auto/config"
+find "$WORKSPACE/config/hooks" -name '*.hook.chroot' -exec chmod +x {} +
 
 cd "$WORKSPACE"
 
@@ -22,11 +24,11 @@ lb clean --purge 2>/dev/null || true
 echo "Configuring live-build..."
 lb config
 
-# Verify distribution is bookworm (catch misconfiguration early)
-if grep -q 'LB_DISTRIBUTION="bookworm"' .build/config 2>/dev/null; then
-    echo "  Distribution: bookworm (OK)"
+# Verify distribution (catch misconfiguration early)
+if grep -q 'LB_DISTRIBUTION="trixie"' .build/config 2>/dev/null; then
+    echo "  Distribution: trixie (OK)"
 else
-    echo "  WARNING: Could not verify distribution is bookworm"
+    echo "  WARNING: Could not verify distribution is trixie"
 fi
 
 # Verify that AIOS binaries are present in the chroot overlay.

--- a/iso/config/archives/sid-kernel.list.chroot
+++ b/iso/config/archives/sid-kernel.list.chroot
@@ -1,0 +1,1 @@
+deb http://deb.debian.org/debian sid main contrib non-free non-free-firmware

--- a/iso/config/archives/sid-kernel.pref.chroot
+++ b/iso/config/archives/sid-kernel.pref.chroot
@@ -1,0 +1,21 @@
+# Default: prevent ALL sid packages from being installed
+Package: *
+Pin: release a=unstable
+Pin-Priority: 50
+
+# Kernel image from sid (nouveau Blackwell needs 6.16+)
+# Headers excluded — they pull gcc-15 which conflicts with Trixie's gcc-14
+Package: linux-image-*
+Pin: release a=unstable
+Pin-Priority: 900
+
+# Firmware from sid (Blackwell GSP firmware for nouveau)
+Package: firmware-*
+Pin: release a=unstable
+Pin-Priority: 900
+
+# Mesa + its runtime deps from sid (NVK Blackwell needs mesa 25.2+)
+# libdrm and libwayland are required by sid mesa and must match
+Package: mesa-* libgl1-mesa-* libegl-mesa* libgbm* libglx-mesa* libgles2-mesa* libegl1-mesa* mesa-libgallium libdrm* libwayland*
+Pin: release a=unstable
+Pin-Priority: 900

--- a/iso/config/auto/config
+++ b/iso/config/auto/config
@@ -2,7 +2,7 @@
 set -e
 
 lb config noauto \
-    --distribution bookworm \
+    --distribution trixie \
     --archive-areas "main contrib non-free non-free-firmware" \
     --architectures amd64 \
     --binary-images iso-hybrid \

--- a/iso/config/hooks/live/00-hardware-fixups.hook.chroot
+++ b/iso/config/hooks/live/00-hardware-fixups.hook.chroot
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -e
+
+# ── Install kernel 6.16+ from sid ──────────────────────────────────
+# Trixie ships kernel 6.12 which lacks nouveau Blackwell (GB203) support.
+# Nouveau for NVIDIA RTX 5070 Ti (GB203) requires kernel 6.16+.
+# The sid repo and pinning are configured in archives/sid-kernel.*.chroot.
+
+echo ">>> Installing sid kernel for Blackwell nouveau support..."
+apt-get update
+# Only install kernel image, NOT headers — sid headers pull gcc-15
+# which conflicts with Trixie's gcc-14. Headers are unnecessary on a live ISO.
+apt-get install -y -t unstable linux-image-amd64
+
+# Remove the old Trixie kernel to keep ISO size down.
+NEWEST=$(ls /boot/vmlinuz-* 2>/dev/null | sort -V | tail -1 | sed 's|/boot/vmlinuz-||')
+if [ -n "$NEWEST" ]; then
+    OLD_KERNELS=$(dpkg -l 'linux-image-[0-9]*' 2>/dev/null \
+        | awk '/^ii/{print $2}' \
+        | grep -v "$NEWEST") || true
+    if [ -n "$OLD_KERNELS" ]; then
+        echo ">>> Removing old kernel(s): $OLD_KERNELS"
+        apt-get purge -y $OLD_KERNELS 2>/dev/null || true
+    fi
+fi
+
+# Also upgrade firmware from sid for Blackwell GSP support
+apt-get install -y -t unstable firmware-nvidia-graphics firmware-misc-nonfree \
+    firmware-linux-nonfree 2>/dev/null || true
+
+# ── Upgrade mesa from sid ─────────────────────────────────────────
+# Trixie ships mesa 25.0 which lacks NVK support for Blackwell (GB203).
+# Mesa 25.2+ (in sid) adds NVK Vulkan + OpenGL via Zink for Blackwell.
+echo ">>> Upgrading mesa for Blackwell NVK support..."
+apt-get install -y -t unstable \
+    mesa-vulkan-drivers libgl1-mesa-dri libegl-mesa0 libgbm1 \
+    libglx-mesa0 mesa-utils 2>/dev/null || true
+
+# ── Remove nouveau blacklist ───────────────────────────────────────
+# nvidia-alternative packages install a modprobe blacklist that blocks
+# nouveau from loading. Remove it so sway can use nouveau as DRM backend.
+rm -f /etc/modprobe.d/nvidia-blacklists-nouveau.conf
+rm -f /etc/modprobe.d/nvidia.conf
+
+apt-get autoremove -y 2>/dev/null || true
+echo ">>> Kernel: $(ls /boot/vmlinuz-* 2>/dev/null | sort -V | tail -1)"

--- a/iso/config/hooks/live/02-setup-sway.hook.chroot
+++ b/iso/config/hooks/live/02-setup-sway.hook.chroot
@@ -18,6 +18,9 @@ exec_always export MOZ_ENABLE_WAYLAND=1
 exec_always export QT_QPA_PLATFORM=wayland
 exec_always export XCURSOR_SIZE=24
 
+# GPU-specific env vars are set by /etc/profile.d/gpu-env.sh at login
+# (auto-detects NVIDIA / AMD / Intel / software fallback)
+
 # Appearance
 default_border pixel 2
 gaps inner 0

--- a/iso/config/hooks/live/03-setup-pipewire.hook.chroot
+++ b/iso/config/hooks/live/03-setup-pipewire.hook.chroot
@@ -3,7 +3,7 @@ set -e
 
 # Enable PipeWire for user session
 # PipeWire runs as user service, enabled via systemd user units
-# These should be auto-enabled on Bookworm but ensure:
+# These should be auto-enabled on Trixie but ensure:
 
 mkdir -p /etc/skel/.config/systemd/user/default.target.wants
 

--- a/iso/config/includes.chroot/etc/profile.d/gpu-env.sh
+++ b/iso/config/includes.chroot/etc/profile.d/gpu-env.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Auto-detect GPU and set Wayland environment accordingly.
+# Supports NVIDIA (proprietary + nouveau/NVK), AMD, Intel, and software fallback.
+#
+# Detection priority: when multiple GPUs are present (e.g. AMD iGPU + NVIDIA dGPU),
+# prefer the one with a working open-source driver for EGL/GLES2 (AMD/Intel).
+# NVIDIA nouveau on modern GPUs uses NVK (Vulkan-only), so sway must use
+# WLR_RENDERER=vulkan instead of the default GLES2 renderer.
+
+HAS_NVIDIA=""
+HAS_AMD=""
+HAS_INTEL=""
+NVIDIA_PROPRIETARY=""
+
+if command -v lspci > /dev/null 2>&1; then
+    lspci_vga=$(lspci -nn 2>/dev/null | grep -iE 'VGA|3D|Display')
+    case "$lspci_vga" in *NVIDIA*|*nvidia*) HAS_NVIDIA=1 ;; esac
+    case "$lspci_vga" in *AMD*|*ATI*|*Radeon*) HAS_AMD=1 ;; esac
+    case "$lspci_vga" in *Intel*|*intel*) HAS_INTEL=1 ;; esac
+fi
+
+# Check if NVIDIA proprietary driver is loaded (not just nouveau)
+if [ -d /sys/module/nvidia ]; then
+    NVIDIA_PROPRIETARY=1
+fi
+
+# Pick the best available GPU for sway/wlroots 0.18+.
+GPU_VENDOR=""
+if [ -n "$NVIDIA_PROPRIETARY" ]; then
+    GPU_VENDOR="nvidia"
+elif [ -n "$HAS_AMD" ]; then
+    GPU_VENDOR="amd"
+elif [ -n "$HAS_INTEL" ]; then
+    GPU_VENDOR="intel"
+elif [ -n "$HAS_NVIDIA" ]; then
+    GPU_VENDOR="nouveau"
+fi
+
+case "$GPU_VENDOR" in
+    nvidia)
+        # Proprietary NVIDIA driver — supports EGL natively
+        export WLR_NO_HARDWARE_CURSORS=1
+        export GBM_BACKEND=nvidia-drm
+        export __GLX_VENDOR_LIBRARY_NAME=nvidia
+        export LIBVA_DRIVER_NAME=nvidia
+        ;;
+    amd)
+        export LIBVA_DRIVER_NAME=radeonsi
+        ;;
+    intel)
+        export LIBVA_DRIVER_NAME=iHD
+        ;;
+    nouveau)
+        # NVK is Vulkan-only — enable Zink so OpenGL/EGL works too
+        # (Zink translates GL calls to Vulkan/NVK)
+        export MESA_LOADER_DRIVER_OVERRIDE=zink
+        # Sway: prefer Vulkan renderer (direct NVK, fastest path)
+        # Falls back to GLES2 via Zink if Vulkan renderer fails
+        export WLR_RENDERER=vulkan
+        export WLR_NO_HARDWARE_CURSORS=1
+        ;;
+    *)
+        # No GPU detected — software rendering
+        export WLR_RENDERER=pixman
+        export LIBGL_ALWAYS_SOFTWARE=1
+        ;;
+esac

--- a/iso/config/package-lists/aios.list.chroot
+++ b/iso/config/package-lists/aios.list.chroot
@@ -1,4 +1,4 @@
-# Window Manager (sway is available in bookworm; labwc is not)
+# Window Manager
 sway
 xwayland
 
@@ -19,7 +19,8 @@ wpasupplicant
 
 # D-Bus and system
 dbus-user-session
-policykit-1
+polkitd
+pkexec
 systemd-sysv
 
 # Fonts
@@ -32,8 +33,24 @@ bash-completion
 curl
 ca-certificates
 
-# Hardware support
+# Firmware (non-free for modern GPU, Wi-Fi, Ethernet hardware)
 firmware-linux-free
+firmware-linux-nonfree
+firmware-misc-nonfree
+firmware-realtek
+firmware-atheros
+firmware-iwlwifi
+firmware-amd-graphics
+firmware-nvidia-graphics
+
+# GPU / Vulkan runtime (required by Iced/wgpu GUI)
+libvulkan1
+mesa-vulkan-drivers
+libgl1-mesa-dri
+mesa-utils
+
+# PCI/USB hardware detection
+pciutils
 
 # Desktop background
 swaybg


### PR DESCRIPTION
Fixes #1 — GUI not starting and network interfaces not visible on modern hardware (NVIDIA RTX 5070 Ti / Blackwell GB203, Realtek RTL8126, Qualcomm FastConnect 7800).

  Root cause: Bookworm ships kernel 6.1 and only free firmware, which lacks drivers for these devices. Nouveau Blackwell support requires kernel 6.16+ and mesa 25.2+ (NVK).

  Changes

  - Base distribution: Bookworm → Trixie (sway/wlroots 0.18, newer userspace)
  - Kernel: 6.16+ from sid via apt pinning (Trixie ships 6.12, Blackwell nouveau needs 6.16+)
  - Mesa: 25.2+ from sid (NVK Vulkan driver for Blackwell GPUs)
  - Firmware: Added non-free firmware packages (realtek, atheros, iwlwifi, amd-graphics, nvidia-graphics)
  - GPU auto-detection: New /etc/profile.d/gpu-env.sh — detects NVIDIA (proprietary + nouveau/NVK), AMD, Intel, or falls back to software rendering
  - Vulkan runtime: Added libvulkan1, mesa-vulkan-drivers for Iced/wgpu GUI
  - Build fix: build-iso.sh now cleans workspace before copy (Docker volume caching bug)

  Sid pinning strategy

  Only kernel, firmware, and mesa are pulled from sid (Priority 900). All other sid packages are blocked (Priority 50). This is temporary until Trixie ships kernel 6.16+.

  Hardware-agnostic GPU support

  - NVIDIA (proprietary) — nvidia-drm, EGL native
  - NVIDIA (nouveau/NVK) — nouveau + NVK, Vulkan renderer + Zink for OpenGL
  - AMD — radeonsi, EGL native
  - Intel — i915/xe, EGL native
  - No GPU detected — pixman software fallback

  Test plan

  - Tested on NVIDIA RTX 5070 Ti (GB203/Blackwell) — sway starts, GUI renders via nouveau/NVK
  - Network interfaces detected (Realtek RTL8126 5GbE)
  - Test on AMD GPU hardware
  - Test on Intel GPU hardware
  - Test in QEMU (software fallback)